### PR TITLE
Fix incremental size reporting. Make rollback to specific bin number.

### DIFF
--- a/squashfu
+++ b/squashfu
@@ -29,7 +29,7 @@ create_new_squash () {
   # If making first seed, create it directly from source
   if [[ $1 -eq -1 ]]; then
     info "Creating seed from sources (this may take a while)"
-    mksquashfs "${INCLUDES[@]}" "$SEED" -b 65536 -e "${EXCLUDES[@]}" >/dev/null
+    mksquashfs "${INCLUDES[@]}" "$SEED" -b 65536 -e "${EXCLUDES[@]}" 
     if [[ $? -eq 0 ]]; then
       mount_squash
       info "Seed creation finished. It has been mounted at "$SQUASH_MOUNT" if you would like to make sure the proper files are included"
@@ -47,7 +47,7 @@ create_new_squash () {
 
   info "Merging old incrementals"
   # Create new squash with temp name, exiting on failure
-  mksquashfs "$UNION_MOUNT" "$SEED.replace" -b 65536 >/dev/null || return 1
+  mksquashfs "$UNION_MOUNT" "$SEED.replace" -b 65536  || return 1
 
   unmount_all
 
@@ -97,8 +97,7 @@ mount_squash () {
 mount_union_with_bins () {
 # Arguments: numbers of bins to be mounted (variable number)
 # Returns: 0 on successful mount, non-zero on failure
-  info "Mounting union"
-  debug "Requested to mount bins: $*"
+  info  "Mounting union and BINs: $*"
 
   # Mount first as rw, shift, and mount the rest ro
   local branches="upperdir=${BINS_DIR}/$1,lowerdir="; shift
@@ -109,6 +108,7 @@ mount_union_with_bins () {
   fi
   branches="${branches}${SQUASH_MOUNT}"
 
+  info "Using command: mount -t overlay overlay -oworkdir=${WORK_DIR},$branches ${UNION_MOUNT}"
   mount -t overlay overlay -oworkdir=$WORK_DIR,$branches "$UNION_MOUNT"
 
   return $?
@@ -257,6 +257,50 @@ action_remove_bin () {
   fi
 }
 
+#action_rollback () {
+## Args: BIN to rollback to
+## Returns: none
+#
+#  [[ $UID -ne 0 ]] && die "Must be root to perform a rollback"
+#  [[ ! $1 =~ ^[0-9]*$ ]] && die "Invalid argument. Parameter must be a number."
+#
+#  target_bin=$1
+#  info "Rolling back to BIN $target_bin" 
+#
+#  # Form a chronologically ordered list of bins, assuming the user didn't give bogus input
+#  local bin_list=($(sed -n 's/[\t\ ]*\([0-9]*\):.*/\1/p' "$BINVENTORY"))
+#  debug "bin_list = ${bin_list[@]}"
+#  local bin_count=${#bin_list[@]}
+#  debug "bin count = ${bin_count}"          
+#
+#  [[ $1 -gt ${#bin_list[@]} ]] && die "Cannot rollback more than ${#bin_list[@]} backups"
+#
+#  #local num_to_mount=$(( ${#bin_list[@]} - $target_bin ))
+#  local num_to_mount=$target_bin
+#  debug "target_bin = ${num_to_mount}"
+#  debug "UNION_MOUNT = $UNION_MOUNT"
+#  debug "SQUASH_MOUNT = $SQUASH_MOUNT"
+#
+#  mountpoint -q "$UNION_MOUNT" && unmount_union
+#  mountpoint -q "$SQUASH_MOUNT" || mount_squash
+#  info "Mount test OK"
+#
+#  if [[ $bin_count -eq 0 ]]; then
+#    local rb_timestamp=0 # XXX: What the hell is the timestamp of the seed... ?
+#  else
+#    # voodoo magic: reverse bin_list and print off the top (#bin_list - $1) bins
+#    #info "BINS to include = " $(for (( i = ${#bin_list[@]} - $1 - 1; i >= 0; i-- )); do echo ${bin_list[i]}; done)
+#    debug "BINS to include = "$(for (( i = $target_bin -1 ; i >= 0; i-- )); do echo ${bin_list[i]}; done)
+#    mount_union_with_bins $(for (( i = $target_bin -1 ; i >= 0; i-- )); do echo ${bin_list[i]}; done)
+#    rb_timestamp=$(grep "^${target_bin}:" "$BINVENTORY" | cut -d: -f2)
+#    debug "rb_timestamp=$rb_timestamp"
+#  fi
+#
+#  info "You have rolled back to bin $target_bin $(date --rfc-3339=seconds --date="@$rb_timestamp")"
+#  info "Your files can be found at '$UNION_MOUNT'"
+#}
+
+
 action_rollback () {
 # Args: number of backups to roll back
 # Returns: none
@@ -264,27 +308,40 @@ action_rollback () {
   [[ $UID -ne 0 ]] && die "Must be root to perform a rollback"
   [[ ! $1 =~ ^[0-9]*$ ]] && die "Invalid argument. Parameter must be a number."
 
+  target_bin=$1
+  info "Rolling back to bin $target_bin"
+
   # Form a chronologically ordered list of bins, assuming the user didn't give bogus input
   local bin_list=($(sed -n 's/[\t\ ]*\([0-9]*\):.*/\1/p' "$BINVENTORY"))
+  info "List of bins = ${bin_list[@]}"
+  local bin_count=${#bin_list[@]}
+  info "Bin count = ${bin_count}"
 
   [[ $1 -gt ${#bin_list[@]} ]] && die "Cannot rollback more than ${#bin_list[@]} backups"
 
-  local num_to_mount=$(( ${#bin_list[@]} - $1 ))
+  #local num_to_mount=$(( ${#bin_list[@]} - $target_bin ))
+  local num_to_mount=$target_bin
+  info "Number of bins to mount = ${num_to_mount}"
 
   mountpoint -q "$UNION_MOUNT" && unmount_union
   mountpoint -q "$SQUASH_MOUNT" || mount_squash
+  info "Squash unmount/remount test OK"
 
-  if [[ ${#bin_list[@]} -eq $1 ]]; then
+  if [[ $bin_count -eq 0 ]]; then
     local rb_timestamp=0 # XXX: What the hell is the timestamp of the seed... ?
   else
     # voodoo magic: reverse bin_list and print off the top (#bin_list - $1) bins
-    mount_union_with_bins $(for (( i = ${#bin_list[@]} - $1 - 1; i >= 0; i-- )); do echo ${bin_list[i]}; done)
-    local rb_timestamp=$(grep "^${bin_list[@]:(-$num_to_mount):1}:" "$BINVENTORY" | cut -d: -f2)
+    #info "Bins to include = " $(for (( i = ${#bin_list[@]} - $1 - 1; i >= 0; i-- )); do echo ${bin_list[i]}; done)
+    info "Bins to include = "$(for (( i = $target_bin -1 ; i >= 0; i-- )); do echo ${bin_list[i]}; done)
+    mount_union_with_bins $(for (( i = $target_bin -1 ; i >= 0; i-- )); do echo ${bin_list[i]}; done)
+    rb_timestamp=$(grep "^${target_bin}:" "$BINVENTORY" | cut -d: -f2)
+    info "Using rb_timestamp=$rb_timestamp"
   fi
 
   info "You have rolled back to $(date --rfc-3339=seconds --date="@$rb_timestamp")"
   info "Your files can be found at '$UNION_MOUNT'"
 }
+
 
 action_report () {
   info "SquashFu Usage Report"
@@ -299,10 +356,10 @@ action_report () {
   printf "\n%30s\r" ".: Loading :." >&2
   while read size bin; do
     case $bin in
-      '.') DATA[0]=$size ;;
-      *) DATA[bin]=$size ;;
+      'total') DATA[0]=$size ;;
+      *) DATA[$bin]=$size ;;
     esac
-  done < <(du -sh . * 2>/dev/null)
+  done < <(du -shc * 2>/dev/null)
   printf "%30s\r" "" >&2
 
   printf "%10s\t%25s\t%7s\n" "Bin ID" "Date Created" "Size"
@@ -446,6 +503,16 @@ HELP
   exit 1
 }
 
+print_config() {
+  info "WORKDIR = $WORK_DIR"
+  info "BKUP_ROOT = $BKUP_ROOT"
+  info "SEED(ro) = $SEED"
+  info "SQUASH_MOUNT = $SQUASH_MOUNT"
+  info "UNION_MOUNT(rw) = $UNION_MOUNT"
+  info "BINS_DIR = $BINS_DIR"
+  info "BINVENTORY = $BINVENTORY"
+}
+
 while getopts :BG:CD:QR:Uc:v opt; do
   case $opt in
     B)
@@ -484,4 +551,7 @@ done
 
 [[ -z $action ]] && usage
 
-action_$action
+LOGNAME=${LOG_DIR}/backup-$(date +%Y%m%d-%H%M).log
+
+print_config 
+action_$action 

--- a/squashfu.conf
+++ b/squashfu.conf
@@ -1,5 +1,3 @@
-# Config file for Super Deluxe SquashFu Backup Express
-
 # Show debugging information. This might be useful in the event
 # you need to troubleshoot.
 DEBUG=false
@@ -11,7 +9,10 @@ COLOR=true
 # This is the only directory that absolutely needs to be
 # created by the user. All others will be created as needed
 # by the actual backup (and inside this root).
-BKUP_ROOT="/this/is/intentionally/a/bad/path"
+BKUP_ROOT="/media/USBHDD/BACKUPS/Pi"           
+
+# LOG file dir
+LOG_DIR=${BKUP_ROOT}
 
 # Location of the 
 BINS_DIR="${BKUP_ROOT}/.bins"
@@ -19,32 +20,36 @@ BINS_DIR="${BKUP_ROOT}/.bins"
 # Mount directories for the union and the squash.
 SQUASH_MOUNT="${BKUP_ROOT}/ro"
 UNION_MOUNT="${BKUP_ROOT}/rw"
-WORK_DIR="${BKUP_ROOT}/work"
+
+#--14.11.2020
+#--Required for overlay filesystems
+WORK_DIR="${BKUP_ROOT}/.workdir"
+#--14.11.2020
 
 # Cheezy name, important file. This is a catalog of your incrementals.
 # Bad things will happen if this file is corrupted or lost.
-BINVENTORY="${BKUP_ROOT}/.squashfu.inv"
+BINVENTORY="/var/lib/bacinc.inv"
 
 # Filename for the seed generated. You shouldn't need
 # to change this
 SEED="${BKUP_ROOT}/$HOSTNAME-seed.sfs"
 
-# The minimum number of incrementals Squashfu will maintain. In other
+# The minimum number of incrementals bacinc will maintain. In other
 # words, if you set this to 10, you will always be able to roll back
 # 10 backups.
-MIN_BINS=5
+MIN_BINS=3
 
-# The maximum number of incremenetals Squashfu will maintain. When this
-# number is reached, Squashfu will automatically merge the oldest
+# The maximum number of incremenetals bacinc will maintain. When this
+# number is reached, bacinc will automatically merge the oldest
 # incrementals until the MIN_BINS is reached. If you set your min and
-# max to be the same value, Squashfu will recompress after every backup.
+# max to be the same value, bacinc will recompress after every backup.
 # Depending on how big your total backup size is, this may not be wise.
-# Warning: It appears that the number of stacked bins is limited by the
-# mount options buffer (1 page, usually 4096 bytes)
-MAX_BINS=10
+# Warning: Without recompiling aufs, there is a limit of 127 branches
+# for an AUFS mount, which means you cannot exceed 127 MAX_BINS.
+MAX_BINS=7 
 
 # Specify the rsync errors which, when encountered, will trigger
-# squashfu to consider the backup to be invalid, and undo the changes
+# bacinc to consider the backup to be invalid, and undo the changes
 # it has already done. That is -- delete the newly allocated bin and
 # update the inventory. See rsync's man page for details about the
 # various exit codes.
@@ -54,21 +59,27 @@ DEL_BIN_ON_FAIL=(1)
 # These are the options that are passed directly to rsync.
 # The -u flag is a necessity, or else incrementals will
 # not be true incrementals. See 'man rsync' for more info.
-RSYNC_OPTS=("-Rua" "--delete" "--stats")
+RSYNC_OPTS=("-vRuaE" "--delete" "--stats")
+#RSYNC_OPTS=("-vuarlkpogREDHAX" "--delete" "--stats")
 
 # The following defines what will and won't be backed up. These are
 # simply Bash arrays and are interpreted as such.
 
 INCLUDES=(
-/home
-/etc
-/usr
-/var
+/
 ) #end includes
 
 EXCLUDES=(
 /lost+found
 /var/log
+/proc
+/sys
+/run
+/var/run
+/dev
+/media
+/mnt
+/lost+found
 ) #end excludes
 
 


### PR DESCRIPTION
Some errors were in the original dev's code.

Fixed: Incremental bin sizes not being reported. 

New: Print config.

Improve: Rollback option method of specifying relative 'n; rollback is unreliable. Changed so that -R x makes rollback to bin 'x'. 
